### PR TITLE
Fix Cargo crate-type field

### DIFF
--- a/jni/Cargo.toml
+++ b/jni/Cargo.toml
@@ -14,4 +14,4 @@ toml = "0.8" # Added for direct TOML parsing
 serde = { version = "1.0", features = ["derive"] } # Added for JniTomlConfig
 
 [lib]
-crate_type = ["cdylib"]
+crate-type = ["cdylib"]

--- a/reader_bench/src/main.rs
+++ b/reader_bench/src/main.rs
@@ -1,7 +1,7 @@
 use std::error::Error;
 use std::time::Instant;
 
-use clap::{self, Parser};
+use clap::Parser;
 
 use shmem::reader;
 

--- a/writer_bench/src/main.rs
+++ b/writer_bench/src/main.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use std::string::String;
 use std::time::Instant;
 
-use clap::{self, Parser};
+use clap::Parser;
 
 use shmem::writer;
 use shmem::reader::{ReaderConfig, MessageReader};


### PR DESCRIPTION
## Summary
- rename deprecated `crate_type` to `crate-type`
- fix clap imports for bench tools

## Testing
- `cargo build --all-targets`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68416f184c648323ae5ee48f16e4fefd